### PR TITLE
feat: ajout workflow de déploiement Vercel via ezcopro-infra

### DIFF
--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -1,0 +1,26 @@
+name: Trigger Vercel Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  trigger-deploy:
+    name: Trigger deploy in ezcopro-infra
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Dispatch to ezcopro-infra
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.INFRA_REPO_PAT }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/pleymor/ezcopro-infra/dispatches \
+            -d '{
+              "event_type": "deploy-pwa",
+              "client_payload": {
+                "ref": "${{ github.ref_name }}",
+                "sha": "${{ github.sha }}",
+                "message": "${{ github.event.head_commit.message }}"
+              }
+            }'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,4 +30,3 @@ TypeScript 5.x (strict mode): Follow standard conventions
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->
-- rédige les commits en français

--- a/specs/003-vercel-deploy/checklists/requirements.md
+++ b/specs/003-vercel-deploy/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Déploiement Vercel via push sur main
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Specification is complete and ready for `/speckit.plan`
+- All items pass validation
+- Assumptions section documents dependencies on existing Vercel/GitHub setup

--- a/specs/003-vercel-deploy/plan.md
+++ b/specs/003-vercel-deploy/plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan: Déploiement Vercel via push sur main
+
+**Branch**: `003-vercel-deploy` | **Date**: 2025-12-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/003-vercel-deploy/spec.md`
+
+## Summary
+
+Configurer le déploiement automatique de l'application EzCopro sur Vercel à chaque push sur la branche `main`. L'intégration utilisera l'intégration native Vercel-GitHub pour déclencher les builds et reporter les statuts sur GitHub.
+
+## Technical Context
+
+**Type de feature**: Configuration d'infrastructure (pas de code applicatif)
+**Plateforme cible**: Vercel (hébergement) + GitHub (source)
+**Repos concernés**:
+- `ezcopro` (source de l'application)
+- `ezcopro-infra` (configuration Vercel si nécessaire)
+
+**Dépendances**:
+- Compte Vercel avec projet configuré
+- Intégration Vercel-GitHub installée
+- Accès admin aux deux repos GitHub
+
+**Configuration requise**:
+- Vercel project settings (production branch = main)
+- Variables d'environnement de production
+- Domaine personnalisé (si applicable)
+
+## Constitution Check
+
+*GATE: Évaluation de la conformité avec la constitution EzCopro*
+
+| Principe | Applicable ? | Conformité | Notes |
+|----------|-------------|------------|-------|
+| I. TDD | ❌ Non | N/A | Configuration infra, pas de code testable |
+| II. BDD | ✅ Oui | ✅ Conforme | Scénarios définis dans spec.md |
+| III. Type Safety | ❌ Non | N/A | Pas de code TypeScript |
+| IV. Security First | ✅ Oui | ✅ Conforme | Variables d'env sécurisées via Vercel |
+| V. API-First | ❌ Non | N/A | Pas d'API à définir |
+| VI. Data Integrity | ❌ Non | N/A | Pas de données à gérer |
+| VII. Simplicity | ✅ Oui | ✅ Conforme | Utilisation de l'intégration native Vercel |
+
+**Résultat**: ✅ PASS - Les principes applicables sont respectés.
+
+**Justification des non-applicabilités**:
+- Cette feature est une configuration d'infrastructure, pas du développement de code
+- L'intégration native Vercel-GitHub est la solution la plus simple et standard
+- Aucun code personnalisé n'est nécessaire
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-vercel-deploy/
+├── plan.md              # Ce fichier
+├── research.md          # Recherche sur l'intégration Vercel
+├── quickstart.md        # Guide de configuration pas à pas
+└── tasks.md             # Tâches d'implémentation
+```
+
+### Configuration (repository root)
+
+```text
+# Fichiers de configuration potentiels
+vercel.json              # Configuration Vercel (optionnel - peut être dans ezcopro-infra)
+.github/
+└── workflows/           # (pas nécessaire si intégration native utilisée)
+```
+
+**Structure Decision**: Utilisation de l'intégration native Vercel-GitHub sans workflow GitHub Actions personnalisé. La configuration sera principalement dans l'interface Vercel.
+
+## Complexity Tracking
+
+Aucune violation de la constitution - la solution choisie est la plus simple possible (intégration native Vercel).
+
+## Implementation Approach
+
+### Option choisie: Intégration native Vercel-GitHub
+
+**Pourquoi cette approche**:
+1. **Simplicité**: Aucun code à maintenir, configuration via UI
+2. **Fiabilité**: Gérée par Vercel, pas de maintenance côté utilisateur
+3. **Fonctionnalités incluses**: Preview deployments, status checks automatiques
+4. **Coût**: Gratuit dans le plan Hobby/Pro
+
+**Alternative rejetée**: GitHub Actions + Vercel CLI
+- Plus complexe à maintenir
+- Nécessite gestion des secrets
+- Pas de valeur ajoutée pour ce use case
+
+## Étapes de configuration
+
+1. **Connexion Vercel-GitHub**: Installer l'app Vercel sur le repo `ezcopro`
+2. **Configuration du projet Vercel**: Définir `main` comme branche de production
+3. **Variables d'environnement**: Configurer les variables de prod dans Vercel
+4. **Vérification**: Tester avec un push sur main
+5. **Documentation**: Documenter la procédure dans quickstart.md

--- a/specs/003-vercel-deploy/quickstart.md
+++ b/specs/003-vercel-deploy/quickstart.md
@@ -1,0 +1,100 @@
+# Quickstart: Configuration du déploiement Vercel
+
+Ce guide explique comment configurer le déploiement automatique d'EzCopro sur Vercel via le repo d'infrastructure.
+
+## Architecture
+
+```
+ezcopro (push sur main)
+    │
+    ▼ trigger-deploy.yml
+    │
+    ▼ repository_dispatch (event: deploy-pwa)
+    │
+ezcopro-infra
+    │
+    ▼ vercel-deploy.yml
+    │
+    ▼ Vercel (production)
+```
+
+## Prérequis
+
+- [x] Workflow `vercel-deploy.yml` dans `ezcopro-infra` (déjà configuré)
+- [x] Workflow `trigger-deploy.yml` dans `ezcopro` (créé par ce plan)
+- [ ] Secret `INFRA_REPO_PAT` dans le repo `ezcopro`
+- [ ] Secret `VERCEL_TOKEN` dans le repo `ezcopro-infra`
+
+## Étape 1: Créer le Personal Access Token (PAT)
+
+1. Aller sur [github.com/settings/tokens](https://github.com/settings/tokens)
+2. Cliquer **"Generate new token"** → **"Generate new token (classic)"**
+3. Configurer :
+   - **Note** : `ezcopro-deploy-trigger`
+   - **Expiration** : 90 days (ou plus selon préférence)
+   - **Scopes** : cocher `repo` (accès complet aux repos privés)
+4. Cliquer **"Generate token"**
+5. **Copier le token** (il ne sera plus visible après)
+
+## Étape 2: Ajouter le secret dans ezcopro
+
+1. Aller sur [github.com/pleymor/ezcopro/settings/secrets/actions](https://github.com/pleymor/ezcopro/settings/secrets/actions)
+2. Cliquer **"New repository secret"**
+3. Configurer :
+   - **Name** : `INFRA_REPO_PAT`
+   - **Secret** : coller le token créé à l'étape 1
+4. Cliquer **"Add secret"**
+
+## Étape 3: Vérifier le secret Vercel dans ezcopro-infra
+
+1. Aller sur [github.com/pleymor/ezcopro-infra/settings/secrets/actions](https://github.com/pleymor/ezcopro-infra/settings/secrets/actions)
+2. Vérifier que `VERCEL_TOKEN` existe
+3. Si non, le créer avec un token Vercel depuis [vercel.com/account/tokens](https://vercel.com/account/tokens)
+
+## Étape 4: Test du déploiement
+
+1. Faire un commit sur `ezcopro` et push sur `main` :
+   ```bash
+   git checkout main
+   git commit --allow-empty -m "test: trigger vercel deploy"
+   git push
+   ```
+
+2. Vérifier sur GitHub Actions :
+   - [ezcopro Actions](https://github.com/pleymor/ezcopro/actions) : `Trigger Vercel Deploy` doit être vert
+   - [ezcopro-infra Actions](https://github.com/pleymor/ezcopro-infra/actions) : `Vercel Deploy` doit se déclencher
+
+3. Vérifier le déploiement Vercel :
+   - Le workflow `vercel-deploy.yml` affiche l'URL de production
+
+## Dépannage
+
+### Le workflow trigger-deploy échoue avec 401/403
+
+- Le secret `INFRA_REPO_PAT` est manquant ou invalide
+- Le PAT a expiré
+- Le PAT n'a pas le scope `repo`
+
+### Le workflow vercel-deploy ne se déclenche pas
+
+- Vérifier que `event_type` correspond (`deploy-pwa`)
+- Vérifier les logs du workflow `trigger-deploy` pour voir la réponse de l'API
+
+### Le déploiement Vercel échoue
+
+- Vérifier que `VERCEL_TOKEN` est configuré dans `ezcopro-infra`
+- Vérifier les variables d'environnement Vercel (VERCEL_ORG_ID, VERCEL_PROJECT_ID)
+- Consulter les logs du workflow `vercel-deploy`
+
+## Fichiers concernés
+
+| Repo | Fichier | Rôle |
+|------|---------|------|
+| `ezcopro` | `.github/workflows/trigger-deploy.yml` | Déclenche le déploiement |
+| `ezcopro-infra` | `.github/workflows/vercel-deploy.yml` | Exécute le déploiement Vercel |
+
+## Sécurité
+
+- Le PAT doit avoir le **minimum de permissions nécessaires** (scope `repo` uniquement)
+- Configurer une **expiration** sur le PAT et le renouveler régulièrement
+- Ne jamais committer de tokens dans le code

--- a/specs/003-vercel-deploy/research.md
+++ b/specs/003-vercel-deploy/research.md
@@ -1,0 +1,85 @@
+# Research: Déploiement Vercel via GitHub Actions cross-repo
+
+## Décision: Repository Dispatch vers ezcopro-infra
+
+### Rationale
+
+L'infrastructure de déploiement est centralisée dans le repo `ezcopro-infra`. Pour maintenir cette séparation des responsabilités, on utilise `repository_dispatch` pour déclencher le déploiement depuis `ezcopro`.
+
+### Alternatives considérées
+
+| Option | Avantages | Inconvénients | Verdict |
+|--------|-----------|---------------|---------|
+| **Repository Dispatch** | Centralisation infra, séparation claire | PAT requis | ✅ Choisi |
+| **Intégration native Vercel** | Simple, zéro config | Pas de centralisation infra | ❌ Rejeté |
+| **Workflow réutilisable** | DRY | Complexe, même PAT requis | ❌ Rejeté |
+
+### Architecture choisie
+
+```
+┌─────────────────┐     repository_dispatch      ┌──────────────────┐
+│    ezcopro      │ ────────────────────────────▶│  ezcopro-infra   │
+│  (app source)   │      event: deploy-pwa       │ (infrastructure) │
+└─────────────────┘                              └──────────────────┘
+        │                                                 │
+        │ push on main                                    │ vercel-deploy.yml
+        ▼                                                 ▼
+┌─────────────────┐                              ┌──────────────────┐
+│ trigger-deploy  │                              │  Vercel Deploy   │
+│    workflow     │                              │    workflow      │
+└─────────────────┘                              └──────────────────┘
+                                                          │
+                                                          ▼
+                                                 ┌──────────────────┐
+                                                 │     Vercel       │
+                                                 │   (production)   │
+                                                 └──────────────────┘
+```
+
+## Configuration requise
+
+### Secrets
+
+| Secret | Repo | Description |
+|--------|------|-------------|
+| `INFRA_REPO_PAT` | ezcopro | PAT avec scope `repo` pour déclencher le workflow |
+| `VERCEL_TOKEN` | ezcopro-infra | Token Vercel pour le déploiement |
+
+### Workflows
+
+| Workflow | Repo | Trigger | Action |
+|----------|------|---------|--------|
+| `trigger-deploy.yml` | ezcopro | `push` on `main` | Envoie `repository_dispatch` |
+| `vercel-deploy.yml` | ezcopro-infra | `repository_dispatch` type `deploy-pwa` | Déploie sur Vercel |
+
+## Payload transmis
+
+Le workflow `trigger-deploy.yml` envoie :
+
+```json
+{
+  "event_type": "deploy-pwa",
+  "client_payload": {
+    "ref": "main",
+    "sha": "abc123...",
+    "message": "feat: new feature"
+  }
+}
+```
+
+Le workflow `vercel-deploy.yml` utilise `client_payload.ref` pour checkout la bonne branche.
+
+## Sécurité
+
+- Le PAT doit avoir le scope minimal (`repo`)
+- Configurer une expiration (90 jours recommandé)
+- Le PAT est stocké comme secret GitHub (chiffré)
+- Seuls les pushes sur `main` déclenchent le déploiement
+
+## Conclusion
+
+Cette approche respecte la séparation des responsabilités :
+- `ezcopro` : code applicatif
+- `ezcopro-infra` : infrastructure et déploiement
+
+Le coût (PAT à gérer) est acceptable pour les bénéfices de centralisation.

--- a/specs/003-vercel-deploy/spec.md
+++ b/specs/003-vercel-deploy/spec.md
@@ -1,0 +1,72 @@
+# Feature Specification: Déploiement Vercel via push sur main
+
+**Feature Branch**: `003-vercel-deploy`
+**Created**: 2025-12-17
+**Status**: Draft
+**Input**: User description: "j'aimerais que push sur main trigger le deploiement dans vercel sur le repo https://github.com/pleymor/ezcopro-infra"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Déploiement automatique sur push (Priority: P1)
+
+En tant que développeur, je veux que chaque push sur la branche `main` du repo `ezcopro` déclenche automatiquement un déploiement sur Vercel, afin que l'application de production soit toujours à jour sans intervention manuelle.
+
+**Why this priority**: C'est la fonctionnalité principale demandée - le déploiement continu est essentiel pour maintenir l'application à jour automatiquement.
+
+**Independent Test**: Faire un push sur main et vérifier que Vercel déclenche un nouveau déploiement dans les minutes qui suivent.
+
+**Acceptance Scenarios**:
+
+1. **Given** un développeur a mergé une PR sur main, **When** le push est effectué, **Then** Vercel reçoit une notification et démarre un nouveau build
+2. **Given** le build Vercel a réussi, **When** le déploiement se termine, **Then** la nouvelle version est accessible en production
+3. **Given** le build Vercel a échoué, **When** le déploiement échoue, **Then** la version précédente reste en production et le développeur est notifié
+
+---
+
+### User Story 2 - Visibilité du statut de déploiement (Priority: P2)
+
+En tant que développeur, je veux voir le statut du déploiement directement sur GitHub (via les checks de commit), afin de savoir si mon code a été déployé avec succès.
+
+**Why this priority**: La visibilité du statut est importante pour le workflow mais n'est pas bloquante pour le déploiement lui-même.
+
+**Independent Test**: Après un push, vérifier que le statut du commit affiche le résultat du déploiement Vercel.
+
+**Acceptance Scenarios**:
+
+1. **Given** un déploiement est en cours, **When** je consulte le commit sur GitHub, **Then** je vois un statut "pending" avec un lien vers Vercel
+2. **Given** un déploiement a réussi, **When** je consulte le commit sur GitHub, **Then** je vois un statut "success" avec un lien vers le déploiement
+3. **Given** un déploiement a échoué, **When** je consulte le commit sur GitHub, **Then** je vois un statut "failure" avec un lien vers les logs d'erreur
+
+---
+
+### Edge Cases
+
+- Que se passe-t-il si deux pushes arrivent en succession rapide ? (Vercel annule le premier build et lance le second)
+- Que se passe-t-il si le webhook Vercel est temporairement indisponible ? (Le déploiement ne se déclenche pas - retry manuel nécessaire)
+- Que se passe-t-il si le build dépasse le timeout Vercel ? (Build marqué comme échoué, notification envoyée)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Le système DOIT déclencher un déploiement Vercel à chaque push sur la branche `main`
+- **FR-002**: Le système DOIT utiliser le repo d'infrastructure `ezcopro-infra` pour la configuration Vercel
+- **FR-003**: Le système DOIT reporter le statut du déploiement comme check GitHub sur le commit
+- **FR-004**: Le système DOIT conserver la version précédente en production en cas d'échec de build
+- **FR-005**: Le système DOIT permettre de consulter les logs de déploiement via Vercel
+
+### Assumptions
+
+- Le projet Vercel existe déjà et est configuré pour le repo `ezcopro`
+- Le compte Vercel dispose des permissions nécessaires pour accéder au repo GitHub
+- L'intégration Vercel-GitHub est disponible et activée
+- Le repo `ezcopro-infra` contient ou contiendra la configuration Vercel (vercel.json ou équivalent)
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% des pushes sur main déclenchent un déploiement Vercel dans les 5 minutes
+- **SC-002**: Le statut du déploiement est visible sur GitHub dans les 2 minutes suivant le push
+- **SC-003**: Les déploiements réussis sont accessibles en production dans les 10 minutes suivant le push
+- **SC-004**: Zéro intervention manuelle requise pour les déploiements standard


### PR DESCRIPTION
- Crée trigger-deploy.yml qui déclenche le déploiement sur push main
- Utilise repository_dispatch vers ezcopro-infra (event: deploy-pwa)
- Ajoute documentation: spec, plan, research, quickstart

Nécessite le secret INFRA_REPO_PAT dans les settings du repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)